### PR TITLE
Added local configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,11 @@
 *.dll
 *.so
 *.dylib
+
+# Local data
 bin/
 artifacts/
+*.local.json
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ debug: build copy
 
 run:
 	@echo Running $(EXECUTABLE)...
-	$(EXECUTABLE)
+	@$(EXECUTABLE)
 
 clean:
 	@echo Cleaning...

--- a/cmd/ada-cli/main.go
+++ b/cmd/ada-cli/main.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	cfgPath := filepath.Join("cfg", "dailylog.json")
-	cfg, err := utils.ParseJsonFile[dailylog.Config](utils.GetAbsolutePath(cfgPath))
+	cfg, err := utils.ParseJsonConfigWithLocal[dailylog.Config](utils.GetAbsolutePath(cfgPath))
 	fmt.Println(cfg)
 	if err != nil {
 		cfg = &dailylog.Config{

--- a/cmd/ada-cli/main.go
+++ b/cmd/ada-cli/main.go
@@ -17,7 +17,7 @@ func main() {
 	cfg, err := utils.ParseJsonFile[dailylog.Config](utils.GetAbsolutePath(cfgPath))
 	fmt.Println(cfg)
 	if err != nil {
-		cfg = dailylog.Config{
+		cfg = &dailylog.Config{
 			Timezone: "local",
 			Path:     utils.GetAbsolutePath("logs"),
 			Prefix:   "ada",

--- a/internal/ada/ada.go
+++ b/internal/ada/ada.go
@@ -42,7 +42,7 @@ func Run(debugMode bool) {
 
 	relativePath := filepath.Join("cfg", "ada.json")
 	cfgPath = utils.GetAbsolutePath(relativePath)
-	cfg, err = utils.ParseJsonFile[config](cfgPath)
+	cfg, err = utils.ParseJsonConfigWithLocal[config](cfgPath)
 	if err != nil {
 		cfg = &defaultCfg
 	}

--- a/internal/ada/ada.go
+++ b/internal/ada/ada.go
@@ -20,9 +20,14 @@ type config struct {
 	ProjName        string `json:"projName"`
 }
 
-var cfg config
+var cfg *config
 var cfgPath string
 var ai llm.LLM
+
+var defaultCfg config = config{
+	ProjRoot: ".projects",
+	Timeout:  "3m",
+}
 
 func Run(debugMode bool) {
 	if debugMode {
@@ -30,13 +35,16 @@ func Run(debugMode bool) {
 		return
 	}
 
-	relativePath := filepath.Join("cfg", "ada.json")
-	cfgPath = utils.GetAbsolutePath(relativePath)
-	cfg = utils.ParseJsonFile[config](cfgPath)
-
 	var err error
 	if ai, err = llm.Resolve(); err != nil {
 		panic(err)
+	}
+
+	relativePath := filepath.Join("cfg", "ada.json")
+	cfgPath = utils.GetAbsolutePath(relativePath)
+	cfg, err = utils.ParseJsonFile[config](cfgPath)
+	if err != nil {
+		cfg = &defaultCfg
 	}
 
 	if cfg.UserName == "" {

--- a/internal/ada/project-creator.go
+++ b/internal/ada/project-creator.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/baudii/ada-ai/pkg/utils"
 )
 
 var projDescrFile string
 var projRoot string
+
+const Artifacts string = "artifacts"
 
 type Node struct {
 	Name     string  `json:"name"`
@@ -112,7 +112,7 @@ func (n *Node) materialize(base string) error {
 }
 
 func createDirectory() error {
-	path := filepath.Join(utils.Artifacts, cfg.ProjRoot, cfg.UserName, cfg.ProjName)
+	path := filepath.Join(Artifacts, cfg.ProjRoot, cfg.UserName, cfg.ProjName)
 	_, err := os.Stat(path)
 	if err == nil {
 		projRoot = path

--- a/pkg/dailylog/dailylog.go
+++ b/pkg/dailylog/dailylog.go
@@ -28,7 +28,7 @@ type dailyWriter struct {
 	file    *os.File
 }
 
-func Init(cfg Config) {
+func Init(cfg *Config) {
 	tz := time.FixedZone(cfg.Timezone, 0)
 	dw := &dailyWriter{
 		path:     cfg.Path,
@@ -70,7 +70,7 @@ func setSlog(w io.Writer, l slog.Level, loc *time.Location) {
 	slog.SetDefault(logger)
 }
 
-func getLogLevelFromCfg(cfg Config) slog.Level {
+func getLogLevelFromCfg(cfg *Config) slog.Level {
 	switch strings.ToLower(cfg.LogLevel) {
 	case "info":
 		return slog.LevelInfo

--- a/pkg/llm/registry.go
+++ b/pkg/llm/registry.go
@@ -22,8 +22,11 @@ func Register(name string, builder ProviderBuilder) {
 
 func Resolve() (LLM, error) {
 	relativePath := filepath.Join("cfg", "llm-provider.json")
-	cfgPath := utils.GetAbsolutePath(relativePath)
-	cfg := utils.ParseJsonFile[config](cfgPath)
+	cfg, err := utils.ParseJsonFile[config](utils.GetAbsolutePath(relativePath))
+	if err != nil {
+		return nil, err
+	}
+
 	builder, ok := registry[cfg.Provider]
 	if !ok {
 		return nil, fmt.Errorf("unknown provider: %s", cfg.Provider)

--- a/pkg/llm/registry.go
+++ b/pkg/llm/registry.go
@@ -22,7 +22,7 @@ func Register(name string, builder ProviderBuilder) {
 
 func Resolve() (LLM, error) {
 	relativePath := filepath.Join("cfg", "llm-provider.json")
-	cfg, err := utils.ParseJsonFile[config](utils.GetAbsolutePath(relativePath))
+	cfg, err := utils.ParseJsonConfigWithLocal[config](utils.GetAbsolutePath(relativePath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/config-parser.go
+++ b/pkg/utils/config-parser.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func ParseJsonFile[T any](basePath string) (*T, error) {
+	baseMap, err := ParseJSONFileToMap(basePath)
+	if err != nil {
+		return nil, fmt.Errorf("read base config: %w", err)
+	}
+
+	ext := filepath.Ext(basePath)
+	name := strings.TrimSuffix(basePath, ext)
+	localPath := name + ".local" + ext
+	if st, err := os.Stat(localPath); err == nil && !st.IsDir() {
+		localMap, err := ParseJSONFileToMap(localPath)
+		if err != nil {
+			return nil, fmt.Errorf("read local config: %w", err)
+		}
+		DeepMerge(baseMap, localMap)
+	}
+
+	mergedBytes, err := json.Marshal(baseMap)
+	if err != nil {
+		return nil, fmt.Errorf("marshal merged config: %w", err)
+	}
+
+	var cfg T
+	if err := json.Unmarshal(mergedBytes, &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal merged into T: %w", err)
+	}
+
+	return &cfg, nil
+}

--- a/pkg/utils/config-parser.go
+++ b/pkg/utils/config-parser.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-func ParseJsonFile[T any](basePath string) (*T, error) {
-	baseMap, err := ParseJSONFileToMap(basePath)
+func ParseJsonConfigWithLocal[T any](basePath string) (*T, error) {
+	baseMap, err := ParseJsonFileToMap(basePath)
 	if err != nil {
 		return nil, fmt.Errorf("read base config: %w", err)
 	}
@@ -18,7 +18,7 @@ func ParseJsonFile[T any](basePath string) (*T, error) {
 	name := strings.TrimSuffix(basePath, ext)
 	localPath := name + ".local" + ext
 	if st, err := os.Stat(localPath); err == nil && !st.IsDir() {
-		localMap, err := ParseJSONFileToMap(localPath)
+		localMap, err := ParseJsonFileToMap(localPath)
 		if err != nil {
 			return nil, fmt.Errorf("read local config: %w", err)
 		}

--- a/pkg/utils/console-utils.go
+++ b/pkg/utils/console-utils.go
@@ -16,7 +16,7 @@ read:
 		line = scanner.Text()
 	}
 
-	if err := scanner.Err(); err == nil {
+	if err := scanner.Err(); err != nil {
 		slog.Error("error reading from stdin", "error", err)
 		goto read
 	}

--- a/pkg/utils/json-utils.go
+++ b/pkg/utils/json-utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 )
 
@@ -19,7 +20,7 @@ func SaveJsonToFile(content any, filePath string) error {
 	return os.WriteFile(filePath, data, 0)
 }
 
-func ParseJsonFile[T any](filePath string) (*T, error) {
+func ParseJsonFileOld[T any](filePath string) (*T, error) {
 	var cfg T
 	file, err := os.ReadFile(filePath)
 	if err != nil {
@@ -32,4 +33,19 @@ func ParseJsonFile[T any](filePath string) (*T, error) {
 	}
 
 	return &cfg, nil
+}
+
+func ParseJSONFileToMap(path string) (map[string]any, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var m map[string]any
+	if err := json.NewDecoder(f).Decode(&m); err != nil {
+		return nil, fmt.Errorf("unmarshal %s: %w", path, err)
+	}
+
+	return m, nil
 }

--- a/pkg/utils/json-utils.go
+++ b/pkg/utils/json-utils.go
@@ -19,17 +19,17 @@ func SaveJsonToFile(content any, filePath string) error {
 	return os.WriteFile(filePath, data, 0)
 }
 
-func ParseJsonFile[T any](filePath string) T {
+func ParseJsonFile[T any](filePath string) (*T, error) {
 	var cfg T
 	file, err := os.ReadFile(filePath)
 	if err != nil {
-		panic(err)
+		return &cfg, err
 	}
 
 	err = json.Unmarshal(file, &cfg)
 	if err != nil {
-		panic(err)
+		return &cfg, err
 	}
 
-	return cfg
+	return &cfg, nil
 }

--- a/pkg/utils/json-utils.go
+++ b/pkg/utils/json-utils.go
@@ -20,7 +20,7 @@ func SaveJsonToFile(content any, filePath string) error {
 	return os.WriteFile(filePath, data, 0)
 }
 
-func ParseJsonFileOld[T any](filePath string) (*T, error) {
+func ParseJsonFile[T any](filePath string) (*T, error) {
 	var cfg T
 	file, err := os.ReadFile(filePath)
 	if err != nil {
@@ -35,7 +35,7 @@ func ParseJsonFileOld[T any](filePath string) (*T, error) {
 	return &cfg, nil
 }
 
-func ParseJSONFileToMap(path string) (map[string]any, error) {
+func ParseJsonFileToMap(path string) (map[string]any, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 )
 
-const Artifacts string = "artifacts"
-
 func GetAbsolutePath(relativePath string) string {
 	exe, err := os.Executable()
 	if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,3 +19,15 @@ func PathExist(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }
+
+func DeepMerge(dst, src map[string]any) {
+	for k, v := range src {
+		if vMap, ok := v.(map[string]any); ok {
+			if dMap, ok := dst[k].(map[string]any); ok {
+				DeepMerge(dMap, vMap)
+				continue
+			}
+		}
+		dst[k] = v
+	}
+}


### PR DESCRIPTION
Resolves #17. Added new configuration parsing logic. Now after parsing of the original configuration file it will be attempted to also parse the same file, but with the .local.json suffix, instead of .json. All the values that exist in the .local file will overwrite those that are in the original configuration file.

This change is needed to keep configuration data locally without risking of pushing it to the repo.